### PR TITLE
update the header of workflow-vis-crc

### DIFF
--- a/inst/pages/seq-workflow-visium-crc.qmd
+++ b/inst/pages/seq-workflow-visium-crc.qmd
@@ -1,14 +1,4 @@
----
-output: html_document
-editor_options: 
-  chunk_output_type: console
----
-
 # Workflow: Visium CRC {#sec-seq-workflow-visium-crc}
-
-```{r include=FALSE}
-knitr::opts_chunk$set(cache=TRUE)
-```
 
 ## Preamble
 


### PR DESCRIPTION
Changes:

- fix the seq-decon schematic png with thicker border
- fix bkg-datasets small description on Janesick breast cell type annotation source and chromium dimension
- merge in seq-workflow-vis-crc p2 subsetting
- add biblio.bib and new two dependencies to DESCRIPTION
- renamed crs-workflow-vishd to seq-workflow-vishd, with content drafted.
- include Lukas new changes on bkg-intro
- remove workflow-vis-crc header 